### PR TITLE
Update versions for k8s and minikube

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,11 @@ inputs:
   minikube-version:
     description: 'Minikube version to install'
     required: false
-    default: '1.4.0'
+    default: '1.6.2'
   k8s-version:
     description: 'Kubernetes version to install'
     required: false
-    default: '1.14.6'
+    default: '1.17.0'
 outputs:
   launcher:
     description: 'Command to execute to launch minikube'


### PR DESCRIPTION
Hi,

@CodingNagger  I would like to say thank you for this action, it helps me a lot.

I found an issue with minikube `1.4.0` with requesting service url from defined namespace, it returns URL with directory files.

for example: 
```
$ minikube service -n monitoring prometheus --url
README.md deploy-and-test.sh fixtures.sh k8s minikube_1.4.0.deb utils.sh http://10.1.0.4:30120
```

First my assumption was: I did something with my bash script wrong.
But actually it was the problem with minikube 1.4.0. It looks like it was fixed in 1.5.2 but I didn't investigate it deeply.

So I updated minikube to 1.6.2 and also Kubernetes to 1.17.0 and everything works like a charm.