### PR TITLE
Use Node.js 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ outputs:
   launcher:
     description: 'Command to execute to launch minikube'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'src/index.js'


### PR DESCRIPTION
Node.js 12 actions are deprecated, see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/